### PR TITLE
refactor: remove deprecated File.exists?

### DIFF
--- a/lib/mork/grid.rb
+++ b/lib/mork/grid.rb
@@ -10,7 +10,7 @@ module Mork
     # Calling Grid.new without arguments creates the default boilerplate Grid
     def initialize(options=nil)
       @params = default_grid
-      if File.exists?('layout.yml')
+      if File.exist?('layout.yml')
         @params.deeper_merge! symbolize YAML.load_file('layout.yml')
       end
       case options

--- a/lib/mork/sheet_pdf.rb
+++ b/lib/mork/sheet_pdf.rb
@@ -13,7 +13,7 @@ module Mork
         when Array; content
         when Hash; [content]
         when String
-          fail Errno::ENOENT unless File.exists? content
+          fail Errno::ENOENT unless File.exist? content
           symbolize YAML.load_file(content)
         end
       @grip =


### PR DESCRIPTION
File.exists? was deprecated since Ruby 2.1 and removed in Ruby 3.2